### PR TITLE
Fix image paste via onpaste attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -592,6 +592,7 @@
             color: var(--text-primary);
             font-size: 14px;
             min-width: 0;
+            resize: none;
         }
 
         .send-btn {
@@ -1095,34 +1096,7 @@
                     loginFormElement.classList.add('initial-entry');
                 }
 
-                // メッセージ入力欄の画像ペースト対応
-                const messageInput = document.getElementById('messageInput');
-                if (messageInput) {
-                    messageInput.addEventListener('paste', (event) => {
-                        if (!event.clipboardData) return;
-                        const items = event.clipboardData.items;
-                        const imageFiles = [];
-                        for (let i = 0; i < items.length; i++) {
-                            const item = items[i];
-                            if (item.kind === 'file' && item.type.startsWith('image/')) {
-                                const file = item.getAsFile();
-                                if (file) imageFiles.push(file);
-                            }
-                        }
-                        if (imageFiles.length > 0) {
-                            // ファイルサイズ制限
-                            const maxSize = 50 * 1024 * 1024;
-                            const oversizedFiles = imageFiles.filter(file => file.size > maxSize);
-                            if (oversizedFiles.length > 0) {
-                                this.showCustomMessageBox('エラー', 'ファイルサイズは50MB以下にしてください。');
-                                return;
-                            }
-                            this.selectedFiles = [...this.selectedFiles, ...imageFiles];
-                            this.render();
-                            event.preventDefault();
-                        }
-                    });
-                }
+                // メッセージ入力欄の画像ペースト対応はHTML側のonpaste属性で処理
             }
 
             loadTheme() {
@@ -1305,35 +1279,7 @@
                     </div>
         `;
 
-                setTimeout(() => {
-                    const messageInput = document.getElementById('messageInput');
-                    if (messageInput && !messageInput._pasteHandlerSet) {
-                        messageInput.addEventListener('paste', (event) => {
-                            if (!event.clipboardData) return;
-                            const items = event.clipboardData.items;
-                            const imageFiles = [];
-                            for (let i = 0; i < items.length; i++) {
-                                const item = items[i];
-                                if (item.kind === 'file' && item.type.startsWith('image/')) {
-                                    const file = item.getAsFile();
-                                    if (file) imageFiles.push(file);
-                                }
-                            }
-                            if (imageFiles.length > 0) {
-                                const maxSize = 50 * 1024 * 1024;
-                                const oversizedFiles = imageFiles.filter(file => file.size > maxSize);
-                                if (oversizedFiles.length > 0) {
-                                    this.showCustomMessageBox('エラー', 'ファイルサイズは50MB以下にしてください。');
-                                    return;
-                                }
-                                this.selectedFiles = [...this.selectedFiles, ...imageFiles];
-                                this.render();
-                                event.preventDefault();
-                            }
-                        });
-                        messageInput._pasteHandlerSet = true;
-                    }
-                }, 0);
+                // textarea側のonpaste属性でハンドラを呼び出すため、ここでのイベント登録は不要
             }
 
             loadCacheFromStorage() {
@@ -2071,6 +2017,38 @@
                 this.render();
             }
 
+            handleImagePaste(event) {
+                if (!event.clipboardData) return;
+                const items = Array.from(event.clipboardData.items || []);
+                const files = Array.from(event.clipboardData.files || []);
+                const imageFiles = [];
+
+                for (const item of items) {
+                    if (item.kind === 'file' && item.type.startsWith('image/')) {
+                        const file = item.getAsFile();
+                        if (file) imageFiles.push(file);
+                    }
+                }
+
+                for (const file of files) {
+                    if (file.type && file.type.startsWith('image/')) {
+                        imageFiles.push(file);
+                    }
+                }
+
+                if (imageFiles.length > 0) {
+                    const maxSize = 50 * 1024 * 1024;
+                    const oversized = imageFiles.filter(f => f.size > maxSize);
+                    if (oversized.length > 0) {
+                        this.showCustomMessageBox('エラー', 'ファイルサイズは50MB以下にしてください。');
+                        return;
+                    }
+                    this.selectedFiles = [...this.selectedFiles, ...imageFiles];
+                    this.render();
+                    event.preventDefault();
+                }
+            }
+
             async sendMessage(channelId, content, messageReference = null) {
                 if ((!content.trim() && this.selectedFiles.length === 0) || this.isSending) return;
 
@@ -2538,7 +2516,7 @@
 
                 const chatHeaderHTML = `<div class="chat-header"><button class="back-btn" onclick="client.unselectChannel()">←</button><div class="chat-title"># ${channelName}</div><div class="chat-header-actions">${inviteButtonHTML}<button class="btn btn-secondary btn-header" onclick="client.fetchMessages('${this.selectedChannel.id}')" ${this.isLoading ? 'disabled' : ''}>${this.isLoading ? '読込中' : '🔄 更新'}</button><button class="btn btn-header" onclick="client.exportMessages()">エクスポート</button></div></div>`;
                 const chatMessagesWrapperHTML = `<div class="chat-messages" id="chat-messages">${chatContentHTML}</div>`;
-                const chatInputAreaHTML = `<div class="chat-input-area">${replyingToHTML}${imagePreviewHTML}<form id="sendMessageForm"><button type="button" class="file-input-btn" onclick="document.getElementById('fileInput').click()">📎</button><input type="file" id="fileInput" class="file-input-hidden" multiple accept="image/*"><textarea id="messageInput" class="message-input" placeholder="#${channelName} へメッセージを送信" autocomplete="off" rows="1"></textarea><button type="submit" id="sendBtn" class="send-btn" ${this.isSending ? 'disabled' : ''}>${this.isSending ? '送信中...' : '送信'}</button></form></div>`;
+                const chatInputAreaHTML = `<div class="chat-input-area">${replyingToHTML}${imagePreviewHTML}<form id="sendMessageForm"><button type="button" class="file-input-btn" onclick="document.getElementById('fileInput').click()">📎</button><input type="file" id="fileInput" class="file-input-hidden" multiple accept="image/*"><textarea id="messageInput" class="message-input" placeholder="#${channelName} へメッセージを送信" autocomplete="off" rows="1" onpaste="client.handleImagePaste(event)"></textarea><button type="submit" id="sendBtn" class="send-btn" ${this.isSending ? 'disabled' : ''}>${this.isSending ? '送信中...' : '送信'}</button></form></div>`;
                 return `<div class="chat-area-wrapper ${animationClass}">${chatHeaderHTML}${chatMessagesWrapperHTML}${chatInputAreaHTML}</div>`;
             }
 


### PR DESCRIPTION
## Summary
- テキストエリアに onpaste を追加して常にペーストイベントを処理
- 画像取得処理を clipboardData.files にも対応させる
- 以前の貼り付けハンドラ登録処理を削除

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687f03044c988322b7eddea60d8b5f85