### PR TITLE
Implement secret reply DM feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -1079,6 +1079,7 @@
                 this.isAnimatingChatOut = false;
                 this.selectedFiles = [];
                 this.replyingTo = null;
+                this.secretReplyingTo = null;
                 this._pendingNewMessages = [];
                 this._newMsgRenderScheduled = false;
 
@@ -2139,6 +2140,40 @@
                 }
             }
 
+            async sendSecretReply(content) {
+                if ((!content.trim() && this.selectedFiles.length === 0) || this.isSending || !this.secretReplyingTo) return;
+
+                const targetUserId = this.secretReplyingTo.author.id;
+                if (targetUserId === this.user.id) {
+                    this.error = '自分にはシークレットリプライできません';
+                    this.render();
+                    return;
+                }
+
+                let dm = this.dms.find(dm => dm.recipients?.[0]?.id === targetUserId);
+                if (!dm) {
+                    const res = await fetch('https://discord.com/api/v9/users/@me/channels', {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': this.token,
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({ recipient_id: targetUserId })
+                    });
+                    if (!res.ok) {
+                        const err = await res.json();
+                        this.error = err.message || 'DM作成に失敗';
+                        this.render();
+                        return;
+                    }
+                    dm = await res.json();
+                    this.dms.unshift(dm);
+                }
+
+                await this.sendMessage(dm.id, content);
+                this.secretReplyingTo = null;
+            }
+
             async deleteMessage(channelId, messageId) {
                 this.showCustomMessageBox('メッセージの削除', '本当にこのメッセージを削除しますか？', false, async () => {
                     try {
@@ -2511,6 +2546,7 @@
                     `<button class="btn btn-secondary btn-header" onclick="client.createInvite('${this.selectedChannel.id}')">招待リンク作成</button>` : '';
 
                 const replyingToHTML = this.replyingTo ? `<div style="background-color: rgba(90, 92, 99, 0.2); padding: 8px 12px; border-left: 4px solid var(--button-primary-bg); border-top-left-radius: 4px; border-top-right-radius: 4px; margin-bottom: -8px; display: flex; align-items: center; justify-content: space-between; color: var(--text-muted); font-size: 13px;"><span><strong style="color: var(--header-primary);">返信先: </strong> ${this.replyingTo.author.global_name || this.replyingTo.author.username}: ${this.replyingTo.content ? (this.replyingTo.content.length > 50 ? this.replyingTo.content.substring(0, 50) + '...' : this.replyingTo.content) : '添付ファイルまたは埋め込み'}</span><button onclick="client.cancelReply()" style="background: none; border: none; color: var(--text-muted); cursor: pointer; font-size: 18px; line-height: 1; padding: 0;">&times;</button></div>` : '';
+                const secretReplyingToHTML = this.secretReplyingTo ? `<div style="background-color: rgba(90, 92, 99, 0.2); padding: 8px 12px; border-left: 4px solid var(--button-primary-bg); border-top-left-radius: 4px; border-top-right-radius: 4px; margin-bottom: -8px; display: flex; align-items: center; justify-content: space-between; color: var(--text-muted); font-size: 13px;"><span><strong style="color: var(--header-primary);">秘密の返信先: </strong> ${this.secretReplyingTo.author.global_name || this.secretReplyingTo.author.username}: ${this.secretReplyingTo.content ? (this.secretReplyingTo.content.length > 50 ? this.secretReplyingTo.content.substring(0, 50) + '...' : this.secretReplyingTo.content) : '添付ファイルまたは埋め込み'}</span><button onclick="client.cancelSecretReply()" style="background: none; border: none; color: var(--text-muted); cursor: pointer; font-size: 18px; line-height: 1; padding: 0;">&times;</button></div>` : '';
 
                 const imagePreviewHTML = this.selectedFiles.length > 0 ? `
                     <div class="image-preview-container">
@@ -2525,7 +2561,7 @@
 
                 const chatHeaderHTML = `<div class="chat-header"><button class="back-btn" onclick="client.unselectChannel()">←</button><div class="chat-title"># ${channelName}</div><div class="chat-header-actions">${inviteButtonHTML}<button class="btn btn-secondary btn-header" onclick="client.fetchMessages('${this.selectedChannel.id}')" ${this.isLoading ? 'disabled' : ''}>${this.isLoading ? '読込中' : '🔄 更新'}</button><button class="btn btn-header" onclick="client.exportMessages()">エクスポート</button></div></div>`;
                 const chatMessagesWrapperHTML = `<div class="chat-messages" id="chat-messages">${chatContentHTML}</div>`;
-                const chatInputAreaHTML = `<div class="chat-input-area">${replyingToHTML}${imagePreviewHTML}<form id="sendMessageForm"><button type="button" class="file-input-btn" onclick="document.getElementById('fileInput').click()">📎</button><input type="file" id="fileInput" class="file-input-hidden" multiple accept="image/*"><textarea id="messageInput" class="message-input" placeholder="#${channelName} へメッセージを送信" autocomplete="off" rows="1"></textarea><button type="submit" id="sendBtn" class="send-btn" ${this.isSending ? 'disabled' : ''}>${this.isSending ? '送信中...' : '送信'}</button></form></div>`;
+                const chatInputAreaHTML = `<div class="chat-input-area">${replyingToHTML}${secretReplyingToHTML}${imagePreviewHTML}<form id="sendMessageForm"><button type="button" class="file-input-btn" onclick="document.getElementById('fileInput').click()">📎</button><input type="file" id="fileInput" class="file-input-hidden" multiple accept="image/*"><textarea id="messageInput" class="message-input" placeholder="#${channelName} へメッセージを送信" autocomplete="off" rows="1"></textarea><button type="submit" id="sendBtn" class="send-btn" ${this.isSending ? 'disabled' : ''}>${this.isSending ? '送信中...' : '送信'}</button></form></div>`;
                 return `<div class="chat-area-wrapper ${animationClass}">${chatHeaderHTML}${chatMessagesWrapperHTML}${chatInputAreaHTML}</div>`;
             }
 
@@ -2572,7 +2608,11 @@
                         e.preventDefault();
                         const input = document.getElementById('messageInput');
                         if (client.selectedChannel) {
-                            client.sendMessage(client.selectedChannel.id, input.value, client.replyingTo ? client.replyingTo.id : null);
+                            if (client.secretReplyingTo) {
+                                client.sendSecretReply(input.value);
+                            } else {
+                                client.sendMessage(client.selectedChannel.id, input.value, client.replyingTo ? client.replyingTo.id : null);
+                            }
                         }
                     };
 
@@ -2654,7 +2694,7 @@
                 contextMenu.className = 'context-menu';
                 contextMenu.style.display = 'none';
 
-                contextMenu.innerHTML = `<li data-action="reply">リプライ</li><li data-action="delete" class="danger">削除</li>`;
+                contextMenu.innerHTML = `<li data-action="reply">リプライ</li><li data-action="secret-reply">シークレットリプライ</li><li data-action="delete" class="danger">削除</li>`;
                 document.body.appendChild(contextMenu);
 
                 let selectedMessageId = null;
@@ -2698,6 +2738,8 @@
                     if (selectedMessageId && client.selectedChannel) {
                         if (action === 'reply') {
                             client.startReply(selectedMessageId);
+                        } else if (action === 'secret-reply') {
+                            client.startSecretReply(selectedMessageId);
                         } else if (action === 'delete') {
                             client.deleteMessage(client.selectedChannel.id, selectedMessageId);
                         }
@@ -2709,6 +2751,7 @@
                 const messageToReply = this.messages.find(m => m.id === messageId);
                 if (messageToReply) {
                     this.replyingTo = messageToReply;
+                    this.secretReplyingTo = null;
                     this.render();
                     document.getElementById('messageInput').focus();
                 }
@@ -2716,6 +2759,21 @@
 
             cancelReply() {
                 this.replyingTo = null;
+                this.render();
+            }
+
+            startSecretReply(messageId) {
+                const message = this.messages.find(m => m.id === messageId);
+                if (message) {
+                    this.secretReplyingTo = message;
+                    this.replyingTo = null;
+                    this.render();
+                    document.getElementById('messageInput').focus();
+                }
+            }
+
+            cancelSecretReply() {
+                this.secretReplyingTo = null;
                 this.render();
             }
         }


### PR DESCRIPTION
## Summary
- add `secretReplyingTo` state and new start/cancel handlers
- extend message context menu with "シークレットリプライ" option
- support sending secret replies via DM creation and message send
- show secret reply target above chat input

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687f7b63db84832296909fec4b325dad